### PR TITLE
Fix string concatenation in logger statements

### DIFF
--- a/src/main/java/de/rub/nds/crawler/targetlist/TargetFileProvider.java
+++ b/src/main/java/de/rub/nds/crawler/targetlist/TargetFileProvider.java
@@ -39,7 +39,7 @@ public class TargetFileProvider implements ITargetListProvider {
         } catch (IOException ex) {
             throw new RuntimeException("Could not load " + filename, ex);
         }
-        LOGGER.info("Read " + targetList.size() + " hosts");
+        LOGGER.info("Read {} hosts", targetList.size());
         return targetList;
     }
 }

--- a/src/main/java/de/rub/nds/crawler/targetlist/ZipFileProvider.java
+++ b/src/main/java/de/rub/nds/crawler/targetlist/ZipFileProvider.java
@@ -50,9 +50,9 @@ public abstract class ZipFileProvider implements ITargetListProvider {
             fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
             fileOutputStream.close();
         } catch (IOException e) {
-            LOGGER.error("Could not download the current " + listName + " list with error ", e);
+            LOGGER.error("Could not download the current {} list with error ", listName, e);
         }
-        LOGGER.info("Unzipping current " + listName + " list...");
+        LOGGER.info("Unzipping current {} list...", listName);
         try (InflaterInputStream zis = getZipInputStream(zipFilename)) {
             if (zis instanceof ZipInputStream) {
                 ((ZipInputStream) zis).getNextEntry();
@@ -67,9 +67,9 @@ public abstract class ZipFileProvider implements ITargetListProvider {
             }
             fos.close();
         } catch (IOException e) {
-            LOGGER.error("Could not unzip the current " + listName + " list with error ", e);
+            LOGGER.error("Could not unzip the current {} list with error ", listName, e);
         }
-        LOGGER.info("Reading first {} hosts from current " + listName + " list...", number);
+        LOGGER.info("Reading first {} hosts from current {} list...", number, listName);
         // currently hosts are in order. e.g. top 1000 hosts come first but that does not have to be
         // the case. Therefore, we parse every line until we hit the specified number of hosts
         try (Stream<String> lines = Files.lines(Paths.get(outputFile))) {
@@ -81,12 +81,12 @@ public abstract class ZipFileProvider implements ITargetListProvider {
         try {
             Files.delete(Path.of(zipFilename));
         } catch (IOException e) {
-            LOGGER.error("Could not delete " + zipFilename + ": ", e);
+            LOGGER.error("Could not delete {}: ", zipFilename, e);
         }
         try {
             Files.delete(Path.of(outputFile));
         } catch (IOException e) {
-            LOGGER.error("Could not delete " + outputFile + ": ", e);
+            LOGGER.error("Could not delete {}: ", outputFile, e);
         }
         return targetList;
     }


### PR DESCRIPTION
## Summary
- Replaced string concatenation with parameterized logging in logger statements
- Fixed 7 instances across TargetFileProvider and ZipFileProvider classes  
- Improves performance by avoiding unnecessary string creation when logging is disabled

Fixes #4