### PR TITLE
Fix Spotbugs EI_EXPOSE_REP issues in config classes

### DIFF
--- a/src/main/java/de/rub/nds/crawler/CommonMain.java
+++ b/src/main/java/de/rub/nds/crawler/CommonMain.java
@@ -13,8 +13,6 @@ import de.rub.nds.crawler.config.ControllerCommandConfig;
 import de.rub.nds.crawler.config.WorkerCommandConfig;
 import de.rub.nds.crawler.core.Controller;
 import de.rub.nds.crawler.core.Worker;
-import de.rub.nds.crawler.orchestration.RabbitMqOrchestrationProvider;
-import de.rub.nds.crawler.persistence.MongoPersistenceProvider;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -49,10 +47,8 @@ public class CommonMain {
                 Worker worker =
                         new Worker(
                                 workerCommandConfig,
-                                new RabbitMqOrchestrationProvider(
-                                        workerCommandConfig.getRabbitMqDelegate()),
-                                new MongoPersistenceProvider(
-                                        workerCommandConfig.getMongoDbDelegate()));
+                                workerCommandConfig.createRabbitMqOrchestrationProvider(),
+                                workerCommandConfig.createMongoPersistenceProvider());
                 worker.start();
                 break;
             case "controller":
@@ -60,10 +56,8 @@ public class CommonMain {
                 Controller controller =
                         new Controller(
                                 controllerCommandConfig,
-                                new RabbitMqOrchestrationProvider(
-                                        controllerCommandConfig.getRabbitMqDelegate()),
-                                new MongoPersistenceProvider(
-                                        controllerCommandConfig.getMongoDbDelegate()));
+                                controllerCommandConfig.createRabbitMqOrchestrationProvider(),
+                                controllerCommandConfig.createMongoPersistenceProvider());
                 controller.start();
                 break;
             default:

--- a/src/main/java/de/rub/nds/crawler/config/ControllerCommandConfig.java
+++ b/src/main/java/de/rub/nds/crawler/config/ControllerCommandConfig.java
@@ -22,6 +22,9 @@ import de.rub.nds.scanner.core.config.ScannerDetail;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.quartz.CronScheduleBuilder;
 
+import de.rub.nds.crawler.orchestration.RabbitMqOrchestrationProvider;
+import de.rub.nds.crawler.persistence.MongoPersistenceProvider;
+
 public abstract class ControllerCommandConfig {
 
     @ParametersDelegate private final RabbitMqDelegate rabbitMqDelegate;
@@ -128,12 +131,20 @@ public abstract class ControllerCommandConfig {
         }
     }
 
-    public RabbitMqDelegate getRabbitMqDelegate() {
+    RabbitMqDelegate getRabbitMqDelegate() {
         return rabbitMqDelegate;
     }
 
-    public MongoDbDelegate getMongoDbDelegate() {
+    MongoDbDelegate getMongoDbDelegate() {
         return mongoDbDelegate;
+    }
+
+    public RabbitMqOrchestrationProvider createRabbitMqOrchestrationProvider() {
+        return new RabbitMqOrchestrationProvider(rabbitMqDelegate);
+    }
+
+    public MongoPersistenceProvider createMongoPersistenceProvider() {
+        return new MongoPersistenceProvider(mongoDbDelegate);
     }
 
     public int getPort() {

--- a/src/main/java/de/rub/nds/crawler/config/ControllerCommandConfig.java
+++ b/src/main/java/de/rub/nds/crawler/config/ControllerCommandConfig.java
@@ -131,14 +131,6 @@ public abstract class ControllerCommandConfig {
         }
     }
 
-    RabbitMqDelegate getRabbitMqDelegate() {
-        return rabbitMqDelegate;
-    }
-
-    MongoDbDelegate getMongoDbDelegate() {
-        return mongoDbDelegate;
-    }
-
     public RabbitMqOrchestrationProvider createRabbitMqOrchestrationProvider() {
         return new RabbitMqOrchestrationProvider(rabbitMqDelegate);
     }

--- a/src/main/java/de/rub/nds/crawler/config/ControllerCommandConfig.java
+++ b/src/main/java/de/rub/nds/crawler/config/ControllerCommandConfig.java
@@ -17,13 +17,12 @@ import de.rub.nds.crawler.config.delegate.RabbitMqDelegate;
 import de.rub.nds.crawler.constant.CruxListNumber;
 import de.rub.nds.crawler.data.BulkScan;
 import de.rub.nds.crawler.data.ScanConfig;
+import de.rub.nds.crawler.orchestration.RabbitMqOrchestrationProvider;
+import de.rub.nds.crawler.persistence.MongoPersistenceProvider;
 import de.rub.nds.crawler.targetlist.*;
 import de.rub.nds.scanner.core.config.ScannerDetail;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.quartz.CronScheduleBuilder;
-
-import de.rub.nds.crawler.orchestration.RabbitMqOrchestrationProvider;
-import de.rub.nds.crawler.persistence.MongoPersistenceProvider;
 
 public abstract class ControllerCommandConfig {
 

--- a/src/main/java/de/rub/nds/crawler/config/WorkerCommandConfig.java
+++ b/src/main/java/de/rub/nds/crawler/config/WorkerCommandConfig.java
@@ -12,6 +12,8 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
 import de.rub.nds.crawler.config.delegate.MongoDbDelegate;
 import de.rub.nds.crawler.config.delegate.RabbitMqDelegate;
+import de.rub.nds.crawler.orchestration.RabbitMqOrchestrationProvider;
+import de.rub.nds.crawler.persistence.MongoPersistenceProvider;
 
 public class WorkerCommandConfig {
 
@@ -43,12 +45,20 @@ public class WorkerCommandConfig {
         mongoDbDelegate = new MongoDbDelegate();
     }
 
-    public RabbitMqDelegate getRabbitMqDelegate() {
+    RabbitMqDelegate getRabbitMqDelegate() {
         return rabbitMqDelegate;
     }
 
-    public MongoDbDelegate getMongoDbDelegate() {
+    MongoDbDelegate getMongoDbDelegate() {
         return mongoDbDelegate;
+    }
+
+    public RabbitMqOrchestrationProvider createRabbitMqOrchestrationProvider() {
+        return new RabbitMqOrchestrationProvider(rabbitMqDelegate);
+    }
+
+    public MongoPersistenceProvider createMongoPersistenceProvider() {
+        return new MongoPersistenceProvider(mongoDbDelegate);
     }
 
     public int getParallelScanThreads() {

--- a/src/main/java/de/rub/nds/crawler/config/WorkerCommandConfig.java
+++ b/src/main/java/de/rub/nds/crawler/config/WorkerCommandConfig.java
@@ -45,14 +45,6 @@ public class WorkerCommandConfig {
         mongoDbDelegate = new MongoDbDelegate();
     }
 
-    RabbitMqDelegate getRabbitMqDelegate() {
-        return rabbitMqDelegate;
-    }
-
-    MongoDbDelegate getMongoDbDelegate() {
-        return mongoDbDelegate;
-    }
-
     public RabbitMqOrchestrationProvider createRabbitMqOrchestrationProvider() {
         return new RabbitMqOrchestrationProvider(rabbitMqDelegate);
     }


### PR DESCRIPTION
## Summary
- Fixed EI_EXPOSE_REP issues in ControllerCommandConfig and WorkerCommandConfig
- Removed direct access to mutable delegate objects
- Added factory methods to create providers instead of exposing delegates