### PR TITLE
Fix SpotBugs JLM_JSR166_UTILCONCURRENT_MONITORENTER issues

### DIFF
--- a/src/main/java/de/rub/nds/crawler/core/BulkScanWorker.java
+++ b/src/main/java/de/rub/nds/crawler/core/BulkScanWorker.java
@@ -24,6 +24,7 @@ public abstract class BulkScanWorker<T extends ScanConfig> {
     private final AtomicInteger activeJobs = new AtomicInteger(0);
     private final AtomicBoolean initialized = new AtomicBoolean(false);
     private final AtomicBoolean shouldCleanupSelf = new AtomicBoolean(false);
+    private final Object initializationLock = new Object();
     protected final String bulkScanId;
     protected final T scanConfig;
 
@@ -67,7 +68,7 @@ public abstract class BulkScanWorker<T extends ScanConfig> {
         // synchronize such that no thread runs before being initialized
         // but only synchronize if not already initialized
         if (!initialized.get()) {
-            synchronized (initialized) {
+            synchronized (initializationLock) {
                 if (!initialized.getAndSet(true)) {
                     initInternal();
                     return true;

--- a/src/main/java/de/rub/nds/crawler/core/BulkScanWorker.java
+++ b/src/main/java/de/rub/nds/crawler/core/BulkScanWorker.java
@@ -82,7 +82,7 @@ public abstract class BulkScanWorker<T extends ScanConfig> {
         // synchronize such that init and cleanup do not run simultaneously
         // but only synchronize if already initialized
         if (initialized.get()) {
-            synchronized (initialized) {
+            synchronized (initializationLock) {
                 if (activeJobs.get() > 0) {
                     shouldCleanupSelf.set(true);
                     LOGGER.warn(


### PR DESCRIPTION
## Summary
- Fixed 2 occurrences of JLM_JSR166_UTILCONCURRENT_MONITORENTER SpotBugs warnings in BulkScanWorker
- Replaced synchronization on AtomicBoolean with a dedicated lock object
- Each fix is in a separate commit as requested