### PR TITLE
Fix SING_SINGLETON_GETTER_NOT_SYNCHRONIZED in BulkScanWorkerManager

### DIFF
--- a/src/main/java/de/rub/nds/crawler/core/BulkScanWorkerManager.java
+++ b/src/main/java/de/rub/nds/crawler/core/BulkScanWorkerManager.java
@@ -24,11 +24,15 @@ import org.bson.Document;
 
 public class BulkScanWorkerManager {
     private static final Logger LOGGER = LogManager.getLogger();
-    private static BulkScanWorkerManager instance;
+    private static volatile BulkScanWorkerManager instance;
 
     public static BulkScanWorkerManager getInstance() {
         if (instance == null) {
-            instance = new BulkScanWorkerManager();
+            synchronized (BulkScanWorkerManager.class) {
+                if (instance == null) {
+                    instance = new BulkScanWorkerManager();
+                }
+            }
         }
         return instance;
     }


### PR DESCRIPTION
## Summary
- Fixed SING_SINGLETON_GETTER_NOT_SYNCHRONIZED SpotBugs issue in BulkScanWorkerManager
- Implemented thread-safe singleton pattern using double-checked locking with volatile field