### PR TITLE
Fix SE_NO_SERIALVERSIONID SpotBugs issue

### DIFF
--- a/src/main/java/de/rub/nds/crawler/data/ScanJobDescription.java
+++ b/src/main/java/de/rub/nds/crawler/data/ScanJobDescription.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 
 public class ScanJobDescription implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final ScanTarget scanTarget;
 
     // Metadata


### PR DESCRIPTION
## Summary
- Fixed SE_NO_SERIALVERSIONID SpotBugs issue in ScanJobDescription class by adding serialVersionUID field