### PR TITLE
Add Javadoc to public methods in de.rub.nds.crawler.core package

### DIFF
--- a/src/main/java/de/rub/nds/crawler/core/BulkScanWorker.java
+++ b/src/main/java/de/rub/nds/crawler/core/BulkScanWorker.java
@@ -48,6 +48,13 @@ public abstract class BulkScanWorker<T extends ScanConfig> {
                         new NamedThreadFactory("crawler-worker: scan executor"));
     }
 
+    /**
+     * Handles a scan target by submitting it to the executor and managing initialization and
+     * cleanup.
+     *
+     * @param scanTarget the target to scan
+     * @return a Future containing the scan result as a Document
+     */
     public Future<Document> handle(ScanTarget scanTarget) {
         // if we initialized ourself, we also clean up ourself
         shouldCleanupSelf.weakCompareAndSetAcquire(false, init());
@@ -62,8 +69,19 @@ public abstract class BulkScanWorker<T extends ScanConfig> {
                 });
     }
 
+    /**
+     * Performs the actual scan operation on the given target.
+     *
+     * @param scanTarget the target to scan
+     * @return a Document containing the scan results
+     */
     public abstract Document scan(ScanTarget scanTarget);
 
+    /**
+     * Initializes the bulk scan worker in a thread-safe manner.
+     *
+     * @return true if initialization was performed, false if already initialized
+     */
     public final boolean init() {
         // synchronize such that no thread runs before being initialized
         // but only synchronize if not already initialized
@@ -78,6 +96,11 @@ public abstract class BulkScanWorker<T extends ScanConfig> {
         return false;
     }
 
+    /**
+     * Cleans up the bulk scan worker resources in a thread-safe manner.
+     *
+     * @return true if cleanup was performed, false if cleanup was deferred or not needed
+     */
     public final boolean cleanup() {
         // synchronize such that init and cleanup do not run simultaneously
         // but only synchronize if already initialized

--- a/src/main/java/de/rub/nds/crawler/core/BulkScanWorkerManager.java
+++ b/src/main/java/de/rub/nds/crawler/core/BulkScanWorkerManager.java
@@ -26,6 +26,11 @@ public class BulkScanWorkerManager {
     private static final Logger LOGGER = LogManager.getLogger();
     private static volatile BulkScanWorkerManager instance;
 
+    /**
+     * Gets the singleton instance of BulkScanWorkerManager.
+     *
+     * @return the singleton instance
+     */
     public static BulkScanWorkerManager getInstance() {
         if (instance == null) {
             synchronized (BulkScanWorkerManager.class) {
@@ -37,6 +42,14 @@ public class BulkScanWorkerManager {
         return instance;
     }
 
+    /**
+     * Static method to handle a scan job using the singleton instance.
+     *
+     * @param scanJobDescription the scan job description
+     * @param parallelConnectionThreads number of parallel connection threads
+     * @param parallelScanThreads number of parallel scan threads
+     * @return a Future containing the scan result document
+     */
     public static Future<Document> handleStatic(
             ScanJobDescription scanJobDescription,
             int parallelConnectionThreads,
@@ -62,6 +75,16 @@ public class BulkScanWorkerManager {
                         .build();
     }
 
+    /**
+     * Gets or creates a BulkScanWorker for the given bulk scan ID.
+     *
+     * @param bulkScanId the unique identifier for the bulk scan
+     * @param scanConfig the scan configuration
+     * @param parallelConnectionThreads number of parallel connection threads
+     * @param parallelScanThreads number of parallel scan threads
+     * @return the BulkScanWorker instance
+     * @throws UncheckedException if worker creation fails
+     */
     public BulkScanWorker<?> getBulkScanWorker(
             String bulkScanId,
             ScanConfig scanConfig,
@@ -83,6 +106,14 @@ public class BulkScanWorkerManager {
         }
     }
 
+    /**
+     * Handles a scan job by delegating to the appropriate BulkScanWorker.
+     *
+     * @param scanJobDescription the scan job description
+     * @param parallelConnectionThreads number of parallel connection threads
+     * @param parallelScanThreads number of parallel scan threads
+     * @return a Future containing the scan result document
+     */
     public Future<Document> handle(
             ScanJobDescription scanJobDescription,
             int parallelConnectionThreads,

--- a/src/main/java/de/rub/nds/crawler/core/Controller.java
+++ b/src/main/java/de/rub/nds/crawler/core/Controller.java
@@ -33,6 +33,13 @@ public class Controller {
     private final ControllerCommandConfig config;
     private IDenylistProvider denylistProvider;
 
+    /**
+     * Creates a new Controller instance.
+     *
+     * @param config the controller command configuration
+     * @param orchestrationProvider the orchestration provider for job management
+     * @param persistenceProvider the persistence provider for data storage
+     */
     public Controller(
             ControllerCommandConfig config,
             IOrchestrationProvider orchestrationProvider,
@@ -45,6 +52,7 @@ public class Controller {
         }
     }
 
+    /** Starts the controller and schedules bulk scan publishing jobs. */
     public void start() {
         ITargetListProvider targetListProvider = config.getTargetListProvider();
 
@@ -91,6 +99,11 @@ public class Controller {
         }
     }
 
+    /**
+     * Shuts down the scheduler if all triggers have been finalized.
+     *
+     * @param scheduler the scheduler to potentially shut down
+     */
     public static void shutdownSchedulerIfAllTriggersFinalized(Scheduler scheduler) {
         try {
             boolean allTriggersFinalized =

--- a/src/main/java/de/rub/nds/crawler/core/ProgressMonitor.java
+++ b/src/main/java/de/rub/nds/crawler/core/ProgressMonitor.java
@@ -47,6 +47,13 @@ public class ProgressMonitor {
 
     private boolean listenerRegistered;
 
+    /**
+     * Creates a new ProgressMonitor instance.
+     *
+     * @param orchestrationProvider the orchestration provider for job management
+     * @param persistenceProvider the persistence provider for data storage
+     * @param scheduler the Quartz scheduler instance
+     */
     public ProgressMonitor(
             IOrchestrationProvider orchestrationProvider,
             IPersistenceProvider persistenceProvider,

--- a/src/main/java/de/rub/nds/crawler/core/Worker.java
+++ b/src/main/java/de/rub/nds/crawler/core/Worker.java
@@ -64,6 +64,7 @@ public class Worker {
                         new NamedThreadFactory("crawler-worker: result handler"));
     }
 
+    /** Starts the worker by registering a scan job consumer with the orchestration provider. */
     public void start() {
         this.orchestrationProvider.registerScanJobConsumer(
                 this::handleScanJob, this.parallelScanThreads);

--- a/src/main/java/de/rub/nds/crawler/core/jobs/PublishBulkScanJob.java
+++ b/src/main/java/de/rub/nds/crawler/core/jobs/PublishBulkScanJob.java
@@ -30,6 +30,12 @@ public class PublishBulkScanJob implements Job {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
+    /**
+     * Executes the bulk scan publishing job.
+     *
+     * @param context the job execution context
+     * @throws JobExecutionException if an error occurs during job execution
+     */
     public void execute(JobExecutionContext context) throws JobExecutionException {
         try {
             JobDataMap data = context.getMergedJobDataMap();


### PR DESCRIPTION
## Summary
- Added Javadoc comments to all public methods and constructors in the de.rub.nds.crawler.core package
- Documented public APIs in BulkScanWorker, BulkScanWorkerManager, Controller, ProgressMonitor, Worker, and PublishBulkScanJob
- All changes follow the existing documentation style and formatting conventions