### PR TITLE
Add Javadoc to public methods in orchestration package

### DIFF
--- a/src/main/java/de/rub/nds/crawler/orchestration/DoneNotificationConsumer.java
+++ b/src/main/java/de/rub/nds/crawler/orchestration/DoneNotificationConsumer.java
@@ -13,5 +13,11 @@ import de.rub.nds.crawler.data.ScanJobDescription;
 @FunctionalInterface
 public interface DoneNotificationConsumer {
 
+    /**
+     * Consumes a notification that a scan job has been completed.
+     *
+     * @param consumerTag The tag identifying the consumer
+     * @param scanJobDescription The completed scan job description
+     */
     void consumeDoneNotification(String consumerTag, ScanJobDescription scanJobDescription);
 }

--- a/src/main/java/de/rub/nds/crawler/orchestration/RabbitMqOrchestrationProvider.java
+++ b/src/main/java/de/rub/nds/crawler/orchestration/RabbitMqOrchestrationProvider.java
@@ -54,6 +54,11 @@ public class RabbitMqOrchestrationProvider implements IOrchestrationProvider {
 
     private Set<String> declaredQueues = new HashSet<>();
 
+    /**
+     * Constructs a new RabbitMQ orchestration provider with the specified configuration.
+     *
+     * @param rabbitMqDelegate The RabbitMQ configuration delegate containing connection parameters
+     */
     public RabbitMqOrchestrationProvider(RabbitMqDelegate rabbitMqDelegate) {
         ConnectionFactory factory = new ConnectionFactory();
         factory.setHost(rabbitMqDelegate.getRabbitMqHost());

--- a/src/main/java/de/rub/nds/crawler/orchestration/ScanJobConsumer.java
+++ b/src/main/java/de/rub/nds/crawler/orchestration/ScanJobConsumer.java
@@ -13,5 +13,10 @@ import de.rub.nds.crawler.data.ScanJobDescription;
 @FunctionalInterface
 public interface ScanJobConsumer {
 
+    /**
+     * Consumes a scan job for processing.
+     *
+     * @param scanJobDescription The scan job to be consumed and processed
+     */
     void consumeScanJob(ScanJobDescription scanJobDescription);
 }


### PR DESCRIPTION
## Summary
- Added Javadoc to all public methods in the `de.rub.nds.crawler.orchestration` package
- Added documentation for `DoneNotificationConsumer.consumeDoneNotification()`
- Added documentation for `ScanJobConsumer.consumeScanJob()`
- Added documentation for `RabbitMqOrchestrationProvider` constructor

## Changes
- Modified 3 files in the orchestration package
- Each change was committed individually as requested
- Methods that override interface methods already inherit Javadoc via @Override