### PR TITLE
Add Javadoc to public methods in de.rub.nds.crawler.targetlist package

### DIFF
--- a/src/main/java/de/rub/nds/crawler/targetlist/CruxListProvider.java
+++ b/src/main/java/de/rub/nds/crawler/targetlist/CruxListProvider.java
@@ -24,6 +24,11 @@ public class CruxListProvider extends ZipFileProvider {
     private static final String ZIP_FILENAME = "current.csv.gz";
     private static final String FILENAME = "current.csv";
 
+    /**
+     * Constructs a CruxListProvider with the specified list size.
+     *
+     * @param cruxListNumber The number of hosts to extract from the Crux list
+     */
     public CruxListProvider(CruxListNumber cruxListNumber) {
         super(cruxListNumber.getNumber(), SOURCE, ZIP_FILENAME, FILENAME, "Crux");
     }

--- a/src/main/java/de/rub/nds/crawler/targetlist/ITargetListProvider.java
+++ b/src/main/java/de/rub/nds/crawler/targetlist/ITargetListProvider.java
@@ -12,5 +12,10 @@ import java.util.List;
 
 public interface ITargetListProvider {
 
+    /**
+     * Retrieves the list of target hosts to scan.
+     *
+     * @return A list of target host names
+     */
     List<String> getTargetList();
 }

--- a/src/main/java/de/rub/nds/crawler/targetlist/TargetFileProvider.java
+++ b/src/main/java/de/rub/nds/crawler/targetlist/TargetFileProvider.java
@@ -23,6 +23,11 @@ public class TargetFileProvider implements ITargetListProvider {
 
     private String filename;
 
+    /**
+     * Constructs a TargetFileProvider with the specified file.
+     *
+     * @param filename Path to the file containing target hosts
+     */
     public TargetFileProvider(String filename) {
         this.filename = filename;
     }

--- a/src/main/java/de/rub/nds/crawler/targetlist/TrancoEmailListProvider.java
+++ b/src/main/java/de/rub/nds/crawler/targetlist/TrancoEmailListProvider.java
@@ -29,6 +29,11 @@ public class TrancoEmailListProvider implements ITargetListProvider {
 
     private final ITargetListProvider trancoList;
 
+    /**
+     * Constructs a TrancoEmailListProvider with the specified Tranco list provider.
+     *
+     * @param trancoList The Tranco list provider to extract email servers from
+     */
     public TrancoEmailListProvider(ITargetListProvider trancoList) {
         this.trancoList = trancoList;
     }

--- a/src/main/java/de/rub/nds/crawler/targetlist/TrancoListProvider.java
+++ b/src/main/java/de/rub/nds/crawler/targetlist/TrancoListProvider.java
@@ -22,6 +22,11 @@ public class TrancoListProvider extends ZipFileProvider {
     private static final String ZIP_FILENAME = "tranco-1m.csv.zip";
     private static final String FILENAME = "tranco-1m.csv";
 
+    /**
+     * Constructs a TrancoListProvider with the specified number of hosts.
+     *
+     * @param number The number of top hosts to extract from the Tranco list
+     */
     public TrancoListProvider(int number) {
         super(number, SOURCE, ZIP_FILENAME, FILENAME, "Tranco");
     }

--- a/src/main/java/de/rub/nds/crawler/targetlist/ZipFileProvider.java
+++ b/src/main/java/de/rub/nds/crawler/targetlist/ZipFileProvider.java
@@ -41,6 +41,11 @@ public abstract class ZipFileProvider implements ITargetListProvider {
         this.listName = listName;
     }
 
+    /**
+     * Downloads, extracts, and processes the target list from the configured zip file source.
+     *
+     * @return A list of target hosts extracted from the downloaded file
+     */
     public List<String> getTargetList() {
         List<String> targetList;
         try {


### PR DESCRIPTION
## Summary
- Added Javadoc comments to all public methods in the de.rub.nds.crawler.targetlist package
- Updated constructors and public methods with proper documentation
- Each change was committed individually for better tracking