### PR TITLE
Add Javadoc to public methods in de.rub.nds.crawler.util package

### DIFF
--- a/src/main/java/de/rub/nds/crawler/util/CanceallableThreadPoolExecutor.java
+++ b/src/main/java/de/rub/nds/crawler/util/CanceallableThreadPoolExecutor.java
@@ -11,6 +11,16 @@ package de.rub.nds.crawler.util;
 import java.util.concurrent.*;
 
 public class CanceallableThreadPoolExecutor extends ThreadPoolExecutor {
+    /**
+     * Creates a new CanceallableThreadPoolExecutor with the given initial parameters.
+     *
+     * @param corePoolSize the number of threads to keep in the pool, even if they are idle
+     * @param maximumPoolSize the maximum number of threads to allow in the pool
+     * @param keepAliveTime when the number of threads is greater than the core, this is the maximum
+     *     time that excess idle threads will wait for new tasks before terminating
+     * @param unit the time unit for the keepAliveTime argument
+     * @param workQueue the queue to use for holding tasks before they are executed
+     */
     public CanceallableThreadPoolExecutor(
             int corePoolSize,
             int maximumPoolSize,
@@ -20,6 +30,18 @@ public class CanceallableThreadPoolExecutor extends ThreadPoolExecutor {
         super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
     }
 
+    /**
+     * Creates a new CanceallableThreadPoolExecutor with the given initial parameters and thread
+     * factory.
+     *
+     * @param corePoolSize the number of threads to keep in the pool, even if they are idle
+     * @param maximumPoolSize the maximum number of threads to allow in the pool
+     * @param keepAliveTime when the number of threads is greater than the core, this is the maximum
+     *     time that excess idle threads will wait for new tasks before terminating
+     * @param unit the time unit for the keepAliveTime argument
+     * @param workQueue the queue to use for holding tasks before they are executed
+     * @param threadFactory the factory to use when the executor creates a new thread
+     */
     public CanceallableThreadPoolExecutor(
             int corePoolSize,
             int maximumPoolSize,
@@ -30,6 +52,19 @@ public class CanceallableThreadPoolExecutor extends ThreadPoolExecutor {
         super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
     }
 
+    /**
+     * Creates a new CanceallableThreadPoolExecutor with the given initial parameters and handler
+     * for rejected tasks.
+     *
+     * @param corePoolSize the number of threads to keep in the pool, even if they are idle
+     * @param maximumPoolSize the maximum number of threads to allow in the pool
+     * @param keepAliveTime when the number of threads is greater than the core, this is the maximum
+     *     time that excess idle threads will wait for new tasks before terminating
+     * @param unit the time unit for the keepAliveTime argument
+     * @param workQueue the queue to use for holding tasks before they are executed
+     * @param handler the handler to use when execution is blocked because the thread bounds and
+     *     queue capacities are reached
+     */
     public CanceallableThreadPoolExecutor(
             int corePoolSize,
             int maximumPoolSize,
@@ -40,6 +75,20 @@ public class CanceallableThreadPoolExecutor extends ThreadPoolExecutor {
         super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler);
     }
 
+    /**
+     * Creates a new CanceallableThreadPoolExecutor with the given initial parameters, thread
+     * factory, and handler for rejected tasks.
+     *
+     * @param corePoolSize the number of threads to keep in the pool, even if they are idle
+     * @param maximumPoolSize the maximum number of threads to allow in the pool
+     * @param keepAliveTime when the number of threads is greater than the core, this is the maximum
+     *     time that excess idle threads will wait for new tasks before terminating
+     * @param unit the time unit for the keepAliveTime argument
+     * @param workQueue the queue to use for holding tasks before they are executed
+     * @param threadFactory the factory to use when the executor creates a new thread
+     * @param handler the handler to use when execution is blocked because the thread bounds and
+     *     queue capacities are reached
+     */
     public CanceallableThreadPoolExecutor(
             int corePoolSize,
             int maximumPoolSize,

--- a/src/main/java/de/rub/nds/crawler/util/CancellableFuture.java
+++ b/src/main/java/de/rub/nds/crawler/util/CancellableFuture.java
@@ -18,6 +18,11 @@ public class CancellableFuture<V> implements RunnableFuture<V> {
     private final RunnableFuture<V> innerFuture;
     private final Semaphore resultWritten = new Semaphore(0);
 
+    /**
+     * Creates a new CancellableFuture that will execute the given Callable.
+     *
+     * @param callable the callable task to execute
+     */
     public CancellableFuture(Callable<V> callable) {
         innerFuture =
                 new FutureTask<>(
@@ -29,6 +34,13 @@ public class CancellableFuture<V> implements RunnableFuture<V> {
                         });
     }
 
+    /**
+     * Creates a new CancellableFuture that will execute the given Runnable and return the specified
+     * result upon completion.
+     *
+     * @param runnable the runnable task to execute
+     * @param res the result to return upon successful completion
+     */
     public CancellableFuture(Runnable runnable, V res) {
         innerFuture =
                 new FutureTask<>(
@@ -40,21 +52,48 @@ public class CancellableFuture<V> implements RunnableFuture<V> {
                         });
     }
 
+    /**
+     * Attempts to cancel execution of this task.
+     *
+     * @param b {@code true} if the thread executing this task should be interrupted; otherwise,
+     *     in-progress tasks are allowed to complete
+     * @return {@code false} if the task could not be cancelled, typically because it has already
+     *     completed normally; {@code true} otherwise
+     */
     @Override
     public boolean cancel(boolean b) {
         return innerFuture.cancel(b);
     }
 
+    /**
+     * Returns {@code true} if this task was cancelled before it completed normally.
+     *
+     * @return {@code true} if this task was cancelled before it completed
+     */
     @Override
     public boolean isCancelled() {
         return innerFuture.isCancelled();
     }
 
+    /**
+     * Returns {@code true} if this task completed.
+     *
+     * @return {@code true} if this task completed
+     */
     @Override
     public boolean isDone() {
         return innerFuture.isDone();
     }
 
+    /**
+     * Waits if necessary for the computation to complete, and then retrieves its result. If the
+     * task was cancelled, this method will still return the result that was computed before
+     * cancellation.
+     *
+     * @return the computed result
+     * @throws InterruptedException if the current thread was interrupted while waiting
+     * @throws ExecutionException if the computation threw an exception
+     */
     @Override
     public V get() throws InterruptedException, ExecutionException {
         try {
@@ -65,6 +104,18 @@ public class CancellableFuture<V> implements RunnableFuture<V> {
         }
     }
 
+    /**
+     * Waits if necessary for at most the given time for the computation to complete, and then
+     * retrieves its result. If the task was cancelled, this method will still return the result
+     * that was computed before cancellation.
+     *
+     * @param l the maximum time to wait
+     * @param timeUnit the time unit of the timeout argument
+     * @return the computed result
+     * @throws InterruptedException if the current thread was interrupted while waiting
+     * @throws ExecutionException if the computation threw an exception
+     * @throws TimeoutException if the wait timed out
+     */
     @Override
     public V get(long l, @NonNull TimeUnit timeUnit)
             throws InterruptedException, ExecutionException, TimeoutException {
@@ -78,6 +129,7 @@ public class CancellableFuture<V> implements RunnableFuture<V> {
         }
     }
 
+    /** Sets this Future to the result of its computation unless it has been cancelled. */
     @Override
     public void run() {
         innerFuture.run();


### PR DESCRIPTION
## Summary
- Added comprehensive Javadoc documentation to all public methods in CanceallableThreadPoolExecutor
- Added comprehensive Javadoc documentation to all public methods in CancellableFuture
- Documentation follows standard Javadoc conventions with parameter and return value descriptions