### PR TITLE
Add unit tests for delegate package

### DIFF
--- a/src/test/java/de/rub/nds/crawler/config/delegate/MongoDbDelegateTest.java
+++ b/src/test/java/de/rub/nds/crawler/config/delegate/MongoDbDelegateTest.java
@@ -1,0 +1,121 @@
+/*
+ * TLS-Crawler - A TLS scanning tool to perform large scale scans with the TLS-Scanner
+ *
+ * Copyright 2018-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.crawler.config.delegate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MongoDbDelegateTest {
+
+    private MongoDbDelegate delegate;
+
+    @BeforeEach
+    void setUp() {
+        delegate = new MongoDbDelegate();
+    }
+
+    @Test
+    void testGetMongoDbHost() {
+        assertNull(delegate.getMongoDbHost());
+    }
+
+    @Test
+    void testSetMongoDbHost() {
+        String host = "localhost";
+        delegate.setMongoDbHost(host);
+        assertEquals(host, delegate.getMongoDbHost());
+    }
+
+    @Test
+    void testGetMongoDbPort() {
+        assertEquals(0, delegate.getMongoDbPort());
+    }
+
+    @Test
+    void testSetMongoDbPort() {
+        int port = 27017;
+        delegate.setMongoDbPort(port);
+        assertEquals(port, delegate.getMongoDbPort());
+    }
+
+    @Test
+    void testGetMongoDbUser() {
+        assertNull(delegate.getMongoDbUser());
+    }
+
+    @Test
+    void testSetMongoDbUser() {
+        String user = "testuser";
+        delegate.setMongoDbUser(user);
+        assertEquals(user, delegate.getMongoDbUser());
+    }
+
+    @Test
+    void testGetMongoDbPass() {
+        assertNull(delegate.getMongoDbPass());
+    }
+
+    @Test
+    void testSetMongoDbPass() {
+        String pass = "testpass";
+        delegate.setMongoDbPass(pass);
+        assertEquals(pass, delegate.getMongoDbPass());
+    }
+
+    @Test
+    void testGetMongoDbPassFile() {
+        assertNull(delegate.getMongoDbPassFile());
+    }
+
+    @Test
+    void testSetMongoDbPassFile() {
+        String passFile = "/path/to/passfile";
+        delegate.setMongoDbPassFile(passFile);
+        assertEquals(passFile, delegate.getMongoDbPassFile());
+    }
+
+    @Test
+    void testGetMongoDbAuthSource() {
+        assertNull(delegate.getMongoDbAuthSource());
+    }
+
+    @Test
+    void testSetMongoDbAuthSource() {
+        String authSource = "admin";
+        delegate.setMongoDbAuthSource(authSource);
+        assertEquals(authSource, delegate.getMongoDbAuthSource());
+    }
+
+    @Test
+    void testAllPropertiesTogether() {
+        String host = "mongodb.example.com";
+        int port = 27018;
+        String user = "appuser";
+        String pass = "apppass";
+        String passFile = "/etc/mongodb/pass";
+        String authSource = "mydb";
+
+        delegate.setMongoDbHost(host);
+        delegate.setMongoDbPort(port);
+        delegate.setMongoDbUser(user);
+        delegate.setMongoDbPass(pass);
+        delegate.setMongoDbPassFile(passFile);
+        delegate.setMongoDbAuthSource(authSource);
+
+        assertEquals(host, delegate.getMongoDbHost());
+        assertEquals(port, delegate.getMongoDbPort());
+        assertEquals(user, delegate.getMongoDbUser());
+        assertEquals(pass, delegate.getMongoDbPass());
+        assertEquals(passFile, delegate.getMongoDbPassFile());
+        assertEquals(authSource, delegate.getMongoDbAuthSource());
+    }
+}

--- a/src/test/java/de/rub/nds/crawler/config/delegate/RabbitMqDelegateTest.java
+++ b/src/test/java/de/rub/nds/crawler/config/delegate/RabbitMqDelegateTest.java
@@ -1,0 +1,125 @@
+/*
+ * TLS-Crawler - A TLS scanning tool to perform large scale scans with the TLS-Scanner
+ *
+ * Copyright 2018-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.crawler.config.delegate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RabbitMqDelegateTest {
+
+    private RabbitMqDelegate delegate;
+
+    @BeforeEach
+    void setUp() {
+        delegate = new RabbitMqDelegate();
+    }
+
+    @Test
+    void testGetRabbitMqHost() {
+        assertNull(delegate.getRabbitMqHost());
+    }
+
+    @Test
+    void testSetRabbitMqHost() {
+        String host = "rabbitmq.example.com";
+        delegate.setRabbitMqHost(host);
+        assertEquals(host, delegate.getRabbitMqHost());
+    }
+
+    @Test
+    void testGetRabbitMqPort() {
+        assertEquals(0, delegate.getRabbitMqPort());
+    }
+
+    @Test
+    void testSetRabbitMqPort() {
+        int port = 5672;
+        delegate.setRabbitMqPort(port);
+        assertEquals(port, delegate.getRabbitMqPort());
+    }
+
+    @Test
+    void testGetRabbitMqUser() {
+        assertNull(delegate.getRabbitMqUser());
+    }
+
+    @Test
+    void testSetRabbitMqUser() {
+        String user = "rabbituser";
+        delegate.setRabbitMqUser(user);
+        assertEquals(user, delegate.getRabbitMqUser());
+    }
+
+    @Test
+    void testGetRabbitMqPass() {
+        assertNull(delegate.getRabbitMqPass());
+    }
+
+    @Test
+    void testSetRabbitMqPass() {
+        String pass = "rabbitpass";
+        delegate.setRabbitMqPass(pass);
+        assertEquals(pass, delegate.getRabbitMqPass());
+    }
+
+    @Test
+    void testGetRabbitMqPassFile() {
+        assertNull(delegate.getRabbitMqPassFile());
+    }
+
+    @Test
+    void testSetRabbitMqPassFile() {
+        String passFile = "/etc/rabbitmq/pass";
+        delegate.setRabbitMqPassFile(passFile);
+        assertEquals(passFile, delegate.getRabbitMqPassFile());
+    }
+
+    @Test
+    void testIsRabbitMqTLS() {
+        assertFalse(delegate.isRabbitMqTLS());
+    }
+
+    @Test
+    void testSetRabbitMqTLS() {
+        delegate.setRabbitMqTLS(true);
+        assertTrue(delegate.isRabbitMqTLS());
+
+        delegate.setRabbitMqTLS(false);
+        assertFalse(delegate.isRabbitMqTLS());
+    }
+
+    @Test
+    void testAllPropertiesTogether() {
+        String host = "rabbitmq.secure.com";
+        int port = 5671;
+        String user = "secureuser";
+        String pass = "securepass";
+        String passFile = "/secure/rabbitmq/pass";
+        boolean tls = true;
+
+        delegate.setRabbitMqHost(host);
+        delegate.setRabbitMqPort(port);
+        delegate.setRabbitMqUser(user);
+        delegate.setRabbitMqPass(pass);
+        delegate.setRabbitMqPassFile(passFile);
+        delegate.setRabbitMqTLS(tls);
+
+        assertEquals(host, delegate.getRabbitMqHost());
+        assertEquals(port, delegate.getRabbitMqPort());
+        assertEquals(user, delegate.getRabbitMqUser());
+        assertEquals(pass, delegate.getRabbitMqPass());
+        assertEquals(passFile, delegate.getRabbitMqPassFile());
+        assertTrue(delegate.isRabbitMqTLS());
+    }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for `MongoDbDelegate` and `RabbitMqDelegate` classes
- Achieve 100% code coverage for the `de.rub.nds.crawler.config.delegate` package
- Ensure all getters, setters, and default behaviors are properly tested