### PR TITLE
Fix IPv6 parsing in ScanTarget (#10)

### DIFF
--- a/src/main/java/de/rub/nds/crawler/data/ScanTarget.java
+++ b/src/main/java/de/rub/nds/crawler/data/ScanTarget.java
@@ -53,13 +53,44 @@ public class ScanTarget implements Serializable {
             System.out.println(targetString);
         }
 
-        // check if targetString contains port (e.g. "www.example.com:8080")
-        // FIXME I guess this breaks any IPv6 parsing
-        if (targetString.contains(":")) {
-            int port = Integer.parseInt(targetString.split(":")[1]);
-            targetString = targetString.split(":")[0];
-            if (port > 1 && port < 65535) {
-                target.setPort(port);
+        // check if targetString contains port (e.g. "www.example.com:8080" or "[2001:db8::1]:8080")
+        // Handle IPv6 addresses with ports (enclosed in brackets)
+        if (targetString.startsWith("[") && targetString.contains("]:")) {
+            int bracketEnd = targetString.indexOf("]:");
+            String ipv6Address = targetString.substring(1, bracketEnd);
+            String portString = targetString.substring(bracketEnd + 2);
+            try {
+                int port = Integer.parseInt(portString);
+                if (port > 1 && port < 65535) {
+                    target.setPort(port);
+                } else {
+                    target.setPort(defaultPort);
+                }
+            } catch (NumberFormatException e) {
+                LOGGER.warn("Invalid port number: {}", portString);
+                target.setPort(defaultPort);
+            }
+            targetString = ipv6Address; // Always extract the IPv6 address
+        } else if (targetString.contains(":")) {
+            // Check if it's an IPv6 address without port or IPv4/hostname with port
+            String[] parts = targetString.split(":");
+            if (parts.length == 2 && !targetString.contains("::")) {
+                // Likely IPv4 or hostname with port
+                try {
+                    int port = Integer.parseInt(parts[1]);
+                    if (port > 1 && port < 65535) {
+                        target.setPort(port);
+                    } else {
+                        target.setPort(defaultPort);
+                    }
+                    targetString = parts[0]; // Always extract the address part
+                } catch (NumberFormatException e) {
+                    // Not a valid port, treat the whole string as address
+                    target.setPort(defaultPort);
+                }
+            } else {
+                // Multiple colons or "::" - likely an IPv6 address without port
+                target.setPort(defaultPort);
             }
         } else {
             target.setPort(defaultPort);

--- a/src/test/java/de/rub/nds/crawler/data/ScanTargetTest.java
+++ b/src/test/java/de/rub/nds/crawler/data/ScanTargetTest.java
@@ -1,0 +1,162 @@
+/*
+ * TLS-Crawler - A TLS scanning tool to perform large scale scans with the TLS-Scanner
+ *
+ * Copyright 2018-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.crawler.data;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.rub.nds.crawler.constant.JobStatus;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+public class ScanTargetTest {
+
+    @Test
+    public void testIPv4WithPort() {
+        Pair<ScanTarget, JobStatus> result =
+                ScanTarget.fromTargetString("192.168.1.1:8080", 443, null);
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        assertEquals("192.168.1.1", result.getLeft().getIp());
+        assertEquals(8080, result.getLeft().getPort());
+        assertNull(result.getLeft().getHostname());
+    }
+
+    @Test
+    public void testIPv4WithoutPort() {
+        Pair<ScanTarget, JobStatus> result = ScanTarget.fromTargetString("192.168.1.1", 443, null);
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        assertEquals("192.168.1.1", result.getLeft().getIp());
+        assertEquals(443, result.getLeft().getPort());
+        assertNull(result.getLeft().getHostname());
+    }
+
+    @Test
+    public void testIPv6WithPort() {
+        Pair<ScanTarget, JobStatus> result =
+                ScanTarget.fromTargetString("[2001:db8::1]:8080", 443, null);
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        assertEquals("2001:db8::1", result.getLeft().getIp());
+        assertEquals(8080, result.getLeft().getPort());
+        assertNull(result.getLeft().getHostname());
+    }
+
+    @Test
+    public void testIPv6WithoutPort() {
+        Pair<ScanTarget, JobStatus> result = ScanTarget.fromTargetString("2001:db8::1", 443, null);
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        assertEquals("2001:db8::1", result.getLeft().getIp());
+        assertEquals(443, result.getLeft().getPort());
+        assertNull(result.getLeft().getHostname());
+    }
+
+    @Test
+    public void testIPv6FullAddressWithPort() {
+        Pair<ScanTarget, JobStatus> result =
+                ScanTarget.fromTargetString(
+                        "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:8443", 443, null);
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        assertEquals("2001:0db8:85a3:0000:0000:8a2e:0370:7334", result.getLeft().getIp());
+        assertEquals(8443, result.getLeft().getPort());
+        assertNull(result.getLeft().getHostname());
+    }
+
+    @Test
+    public void testIPv6CompressedAddress() {
+        Pair<ScanTarget, JobStatus> result = ScanTarget.fromTargetString("::1", 443, null);
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        assertEquals("::1", result.getLeft().getIp());
+        assertEquals(443, result.getLeft().getPort());
+        assertNull(result.getLeft().getHostname());
+    }
+
+    @Test
+    public void testHostnameWithPort() {
+        Pair<ScanTarget, JobStatus> result =
+                ScanTarget.fromTargetString("example.com:8080", 443, null);
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        assertEquals("example.com", result.getLeft().getHostname());
+        assertEquals(8080, result.getLeft().getPort());
+        // IP will be resolved by DNS lookup, so we can't test the exact value
+        assertNotNull(result.getLeft().getIp());
+    }
+
+    @Test
+    public void testHostnameWithoutPort() {
+        Pair<ScanTarget, JobStatus> result = ScanTarget.fromTargetString("example.com", 443, null);
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        assertEquals("example.com", result.getLeft().getHostname());
+        assertEquals(443, result.getLeft().getPort());
+        assertNotNull(result.getLeft().getIp());
+    }
+
+    @Test
+    public void testInvalidPortRangeHigh() {
+        Pair<ScanTarget, JobStatus> result =
+                ScanTarget.fromTargetString("192.168.1.1:70000", 443, null);
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        assertEquals("192.168.1.1", result.getLeft().getIp());
+        assertEquals(443, result.getLeft().getPort()); // Should use default port
+    }
+
+    @Test
+    public void testInvalidPortRangeLow() {
+        Pair<ScanTarget, JobStatus> result =
+                ScanTarget.fromTargetString("192.168.1.1:0", 443, null);
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        assertEquals("192.168.1.1", result.getLeft().getIp());
+        assertEquals(443, result.getLeft().getPort()); // Should use default port
+    }
+
+    @Test
+    public void testInvalidPortFormat() {
+        Pair<ScanTarget, JobStatus> result =
+                ScanTarget.fromTargetString("[2001:db8::1]:abc", 443, null);
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        assertEquals("2001:db8::1", result.getLeft().getIp());
+        assertEquals(443, result.getLeft().getPort()); // Should use default port
+    }
+
+    @Test
+    public void testTrancoRankWithIPv4() {
+        Pair<ScanTarget, JobStatus> result =
+                ScanTarget.fromTargetString("100,192.168.1.1:8080", 443, null);
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        assertEquals("192.168.1.1", result.getLeft().getIp());
+        assertEquals(8080, result.getLeft().getPort());
+        assertEquals(100, result.getLeft().getTrancoRank());
+    }
+
+    @Test
+    public void testTrancoRankWithIPv6() {
+        Pair<ScanTarget, JobStatus> result =
+                ScanTarget.fromTargetString("200,[2001:db8::1]:8080", 443, null);
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        assertEquals("2001:db8::1", result.getLeft().getIp());
+        assertEquals(8080, result.getLeft().getPort());
+        assertEquals(200, result.getLeft().getTrancoRank());
+    }
+
+    @Test
+    public void testUnknownHost() {
+        Pair<ScanTarget, JobStatus> result =
+                ScanTarget.fromTargetString("this-host-should-not-exist-12345.com", 443, null);
+        assertEquals(JobStatus.UNRESOLVABLE, result.getRight());
+        assertEquals("this-host-should-not-exist-12345.com", result.getLeft().getHostname());
+        assertNull(result.getLeft().getIp());
+    }
+
+    @Test
+    public void testMalformedIPv6Bracket() {
+        // Missing closing bracket - should result in UNRESOLVABLE
+        Pair<ScanTarget, JobStatus> result =
+                ScanTarget.fromTargetString("[2001:db8::1:8080", 443, null);
+        assertEquals(JobStatus.UNRESOLVABLE, result.getRight());
+        // Should use default port
+        assertEquals(443, result.getLeft().getPort());
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed IPv6 address parsing in ScanTarget class that was breaking when handling IPv6 addresses with ports
- Implemented proper handling for IPv6 bracket notation `[addr]:port`
- Added comprehensive test coverage for various address formats

## Changes
1. **IPv6 with port support**: Now correctly parses `[2001:db8::1]:8080` format
2. **IPv6 without port**: Properly handles addresses like `2001:db8::1` and `::1`
3. **Invalid port handling**: Always extracts the address part even when port is invalid
4. **Test coverage**: Added 15 tests covering IPv4, IPv6, hostnames, and edge cases

## Test plan
- [x] All new tests pass successfully
- [x] Tested IPv4 addresses with and without ports
- [x] Tested IPv6 addresses with bracket notation and ports
- [x] Tested IPv6 addresses without ports (including compressed notation)
- [x] Tested hostnames with and without ports
- [x] Tested invalid port ranges and formats
- [x] Tested malformed inputs

Fixes #10