### PR TITLE
feat: Support multiple IPs per hostname in ScanTarget

### DIFF
--- a/src/main/java/de/rub/nds/crawler/denylist/DenylistFileProvider.java
+++ b/src/main/java/de/rub/nds/crawler/denylist/DenylistFileProvider.java
@@ -69,9 +69,19 @@ public class DenylistFileProvider implements IDenylistProvider {
 
     @Override
     public synchronized boolean isDenylisted(ScanTarget target) {
-        return domainDenylistSet.contains(target.getHostname())
-                || ipDenylistSet.contains(target.getIp())
-                || cidrDenylist.stream()
-                        .anyMatch(subnetInfo -> isInSubnet(target.getIp(), subnetInfo));
+        // Check if hostname is denylisted
+        if (domainDenylistSet.contains(target.getHostname())) {
+            return true;
+        }
+
+        // Check if any of the IPs are denylisted
+        for (String ip : target.getIps()) {
+            if (ipDenylistSet.contains(ip)
+                    || cidrDenylist.stream().anyMatch(subnetInfo -> isInSubnet(ip, subnetInfo))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/main/java/de/rub/nds/crawler/persistence/MongoPersistenceProvider.java
+++ b/src/main/java/de/rub/nds/crawler/persistence/MongoPersistenceProvider.java
@@ -192,7 +192,9 @@ public class MongoPersistenceProvider implements IPersistenceProvider {
                                 ScanResult.class,
                                 UuidRepresentation.STANDARD);
         // createIndex is idempotent, hence we do not need to check if an index exists
-        collection.createIndex(Indexes.ascending("scanTarget.ip"));
+        collection.createIndex(
+                Indexes.ascending("scanTarget.ip")); // Keep for backward compatibility
+        collection.createIndex(Indexes.ascending("scanTarget.ips")); // Index for multiple IPs
         collection.createIndex(Indexes.ascending("scanTarget.hostname"));
         collection.createIndex(Indexes.ascending("scanTarget.trancoRank"));
         collection.createIndex(Indexes.ascending("scanTarget.resultStatus"));

--- a/src/test/java/de/rub/nds/crawler/data/ScanTargetTest.java
+++ b/src/test/java/de/rub/nds/crawler/data/ScanTargetTest.java
@@ -1,0 +1,134 @@
+/*
+ * TLS-Crawler - A TLS scanning tool to perform large scale scans with the TLS-Scanner
+ *
+ * Copyright 2018-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.crawler.data;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.rub.nds.crawler.constant.JobStatus;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+class ScanTargetTest {
+
+    @Test
+    void testFromTargetStringWithHostname() {
+        // Test hostname resolution to multiple IPs
+        Pair<ScanTarget, JobStatus> result = ScanTarget.fromTargetString("localhost", 443, null);
+
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        ScanTarget target = result.getLeft();
+
+        assertEquals("localhost", target.getHostname());
+        assertEquals(443, target.getPort());
+        assertNotNull(target.getIps());
+        assertFalse(target.getIps().isEmpty());
+        // localhost should resolve to at least one IP
+        assertTrue(target.getIps().size() >= 1);
+        // The deprecated getIp() should return the first IP
+        assertEquals(target.getIps().get(0), target.getIp());
+    }
+
+    @Test
+    void testFromTargetStringWithIpAddress() {
+        Pair<ScanTarget, JobStatus> result = ScanTarget.fromTargetString("127.0.0.1", 443, null);
+
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        ScanTarget target = result.getLeft();
+
+        assertNull(target.getHostname());
+        assertEquals("127.0.0.1", target.getIp());
+        assertEquals(Arrays.asList("127.0.0.1"), target.getIps());
+        assertEquals(443, target.getPort());
+    }
+
+    @Test
+    void testFromTargetStringWithPort() {
+        Pair<ScanTarget, JobStatus> result =
+                ScanTarget.fromTargetString("127.0.0.1:8443", 443, null);
+
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        ScanTarget target = result.getLeft();
+
+        assertEquals("127.0.0.1", target.getIp());
+        assertEquals(Arrays.asList("127.0.0.1"), target.getIps());
+        assertEquals(8443, target.getPort());
+    }
+
+    @Test
+    void testFromTargetStringWithTrancoRank() {
+        Pair<ScanTarget, JobStatus> result =
+                ScanTarget.fromTargetString("100,127.0.0.1", 443, null);
+
+        assertEquals(JobStatus.TO_BE_EXECUTED, result.getRight());
+        ScanTarget target = result.getLeft();
+
+        assertEquals(100, target.getTrancoRank());
+        assertEquals("127.0.0.1", target.getIp());
+        assertEquals(Arrays.asList("127.0.0.1"), target.getIps());
+    }
+
+    @Test
+    void testFromTargetStringUnresolvableHost() {
+        Pair<ScanTarget, JobStatus> result =
+                ScanTarget.fromTargetString("this-host-should-not-exist-12345.invalid", 443, null);
+
+        assertEquals(JobStatus.UNRESOLVABLE, result.getRight());
+    }
+
+    @Test
+    void testSetIpsAndBackwardCompatibility() {
+        ScanTarget target = new ScanTarget();
+        List<String> ips = Arrays.asList("192.168.1.1", "192.168.1.2", "192.168.1.3");
+
+        target.setIps(ips);
+
+        // Check that all IPs are stored
+        assertEquals(ips, target.getIps());
+        // Check backward compatibility - getIp() should return the first IP
+        assertEquals("192.168.1.1", target.getIp());
+    }
+
+    @Test
+    void testSetIpBackwardCompatibility() {
+        ScanTarget target = new ScanTarget();
+
+        // Test deprecated setIp method
+        target.setIp("10.0.0.1");
+
+        assertEquals("10.0.0.1", target.getIp());
+        assertEquals(Arrays.asList("10.0.0.1"), target.getIps());
+
+        // Setting another IP should update the list
+        target.setIp("10.0.0.2");
+        assertEquals("10.0.0.2", target.getIp());
+        assertEquals(Arrays.asList("10.0.0.2"), target.getIps());
+    }
+
+    @Test
+    void testToStringWithMultipleIps() {
+        ScanTarget target = new ScanTarget();
+
+        // Test with hostname
+        target.setHostname("example.com");
+        target.setIps(Arrays.asList("192.168.1.1", "192.168.1.2"));
+        assertEquals("example.com", target.toString());
+
+        // Test with single IP (no hostname)
+        target = new ScanTarget();
+        target.setIps(Arrays.asList("192.168.1.1"));
+        assertEquals("192.168.1.1", target.toString());
+
+        // Test with multiple IPs (no hostname)
+        target = new ScanTarget();
+        target.setIps(Arrays.asList("192.168.1.1", "192.168.1.2", "192.168.1.3"));
+        assertEquals("[192.168.1.1, 192.168.1.2, 192.168.1.3]", target.toString());
+    }
+}

--- a/src/test/java/de/rub/nds/crawler/denylist/DenylistFileProviderTest.java
+++ b/src/test/java/de/rub/nds/crawler/denylist/DenylistFileProviderTest.java
@@ -1,0 +1,142 @@
+/*
+ * TLS-Crawler - A TLS scanning tool to perform large scale scans with the TLS-Scanner
+ *
+ * Copyright 2018-2022 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.crawler.denylist;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.rub.nds.crawler.data.ScanTarget;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Arrays;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DenylistFileProviderTest {
+
+    @TempDir File tempDir;
+
+    private File denylistFile;
+    private DenylistFileProvider provider;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        denylistFile = new File(tempDir, "denylist.txt");
+        writeDenylistFile();
+        provider = new DenylistFileProvider(denylistFile.getAbsolutePath());
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (denylistFile.exists()) {
+            denylistFile.delete();
+        }
+    }
+
+    private void writeDenylistFile() throws IOException {
+        try (FileWriter writer = new FileWriter(denylistFile)) {
+            // Domain denylists
+            writer.write("example.com\n");
+            writer.write("blocked-domain.org\n");
+            // IP denylists
+            writer.write("192.168.1.100\n");
+            writer.write("10.0.0.50\n");
+            // CIDR denylists
+            writer.write("172.16.0.0/16\n");
+            writer.write("203.0.113.0/24\n");
+        }
+    }
+
+    @Test
+    void testIsDenylistedWithBlockedDomain() {
+        ScanTarget target = new ScanTarget();
+        target.setHostname("example.com");
+        target.setIps(Arrays.asList("1.2.3.4", "5.6.7.8"));
+
+        assertTrue(provider.isDenylisted(target));
+    }
+
+    @Test
+    void testIsDenylistedWithAllowedDomain() {
+        ScanTarget target = new ScanTarget();
+        target.setHostname("allowed-domain.com");
+        target.setIps(Arrays.asList("1.2.3.4", "5.6.7.8"));
+
+        assertFalse(provider.isDenylisted(target));
+    }
+
+    @Test
+    void testIsDenylistedWithBlockedSingleIp() {
+        ScanTarget target = new ScanTarget();
+        target.setHostname("allowed-domain.com");
+        target.setIps(Arrays.asList("192.168.1.100"));
+
+        assertTrue(provider.isDenylisted(target));
+    }
+
+    @Test
+    void testIsDenylistedWithMultipleIpsOneBlocked() {
+        ScanTarget target = new ScanTarget();
+        target.setHostname("allowed-domain.com");
+        // One IP is blocked, others are not
+        target.setIps(Arrays.asList("1.2.3.4", "192.168.1.100", "5.6.7.8"));
+
+        assertTrue(provider.isDenylisted(target));
+    }
+
+    @Test
+    void testIsDenylistedWithMultipleIpsNoneBlocked() {
+        ScanTarget target = new ScanTarget();
+        target.setHostname("allowed-domain.com");
+        target.setIps(Arrays.asList("1.2.3.4", "5.6.7.8", "9.10.11.12"));
+
+        assertFalse(provider.isDenylisted(target));
+    }
+
+    @Test
+    void testIsDenylistedWithCidrBlockedIp() {
+        ScanTarget target = new ScanTarget();
+        target.setHostname("allowed-domain.com");
+        // IP is in the 172.16.0.0/16 CIDR range
+        target.setIps(Arrays.asList("172.16.5.10"));
+
+        assertTrue(provider.isDenylisted(target));
+    }
+
+    @Test
+    void testIsDenylistedWithMultipleIpsOneCidrBlocked() {
+        ScanTarget target = new ScanTarget();
+        target.setHostname("allowed-domain.com");
+        // One IP is in CIDR range, others are not
+        target.setIps(Arrays.asList("1.2.3.4", "203.0.113.50", "5.6.7.8"));
+
+        assertTrue(provider.isDenylisted(target));
+    }
+
+    @Test
+    void testIsDenylistedWithEmptyIpsList() {
+        ScanTarget target = new ScanTarget();
+        target.setHostname("allowed-domain.com");
+        target.setIps(Arrays.asList());
+
+        assertFalse(provider.isDenylisted(target));
+    }
+
+    @Test
+    void testBackwardCompatibilityWithDeprecatedIpField() {
+        ScanTarget target = new ScanTarget();
+        target.setHostname("allowed-domain.com");
+        // Use deprecated setIp method
+        target.setIp("10.0.0.50");
+
+        assertTrue(provider.isDenylisted(target));
+    }
+}


### PR DESCRIPTION
## Summary
- Enhanced ScanTarget to support multiple IP addresses per hostname
- Implemented backward-compatible solution maintaining existing API
- Updated related components to handle multiple IPs correctly

## Changes
- Modified `ScanTarget` class to store multiple IPs in a `List<String>` field
- Updated `fromTargetString()` method to resolve all IP addresses using `InetAddress.getAllByName()`
- Maintained backward compatibility by keeping the existing `ip` field and marking `getIp()`/`setIp()` as deprecated
- Updated `DenylistFileProvider` to check all IPs when evaluating denylists
- Added MongoDB index for the new `ips` field to support efficient queries
- Added comprehensive unit tests for both `ScanTarget` and `DenylistFileProvider`

## Test Plan
- [x] Added unit tests for ScanTarget multiple IP functionality
- [x] Added unit tests for DenylistFileProvider with multiple IPs
- [x] All existing tests pass without modification
- [x] Manual testing with hostnames that resolve to multiple IPs

Fixes #11