### PR TITLE
Fix deprecated URL constructor in ZipFileProvider

### DIFF
--- a/src/main/java/de/rub/nds/crawler/targetlist/ZipFileProvider.java
+++ b/src/main/java/de/rub/nds/crawler/targetlist/ZipFileProvider.java
@@ -9,6 +9,7 @@
 package de.rub.nds.crawler.targetlist;
 
 import java.io.*;
+import java.net.URI;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
@@ -45,7 +46,7 @@ public abstract class ZipFileProvider implements ITargetListProvider {
         List<String> targetList;
         try {
             ReadableByteChannel readableByteChannel =
-                    Channels.newChannel(new URL(sourceUrl).openStream());
+                    Channels.newChannel(URL.of(URI.create(sourceUrl), null).openStream());
             FileOutputStream fileOutputStream = new FileOutputStream(zipFilename);
             fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
             fileOutputStream.close();


### PR DESCRIPTION
## Summary
- Fixed deprecated `URL(String)` constructor usage in `ZipFileProvider.java`
- Replaced with `URL.of(URI.create(String), null)` to resolve Java 20+ deprecation warning
- This change maintains the same functionality while addressing the deprecation issue

## Test plan
- [x] Code compiles without deprecation warnings
- [x] Build passes with `mvn clean compile`
- [x] Code formatting applied with `mvn spotless:apply`