### PR TITLE
Fix resource leaks in ZipFileProvider

### DIFF
--- a/src/main/java/de/rub/nds/crawler/targetlist/ZipFileProvider.java
+++ b/src/main/java/de/rub/nds/crawler/targetlist/ZipFileProvider.java
@@ -43,12 +43,10 @@ public abstract class ZipFileProvider implements ITargetListProvider {
 
     public List<String> getTargetList() {
         List<String> targetList;
-        try {
-            ReadableByteChannel readableByteChannel =
-                    Channels.newChannel(new URL(sourceUrl).openStream());
-            FileOutputStream fileOutputStream = new FileOutputStream(zipFilename);
+        try (ReadableByteChannel readableByteChannel =
+                        Channels.newChannel(new URL(sourceUrl).openStream());
+                FileOutputStream fileOutputStream = new FileOutputStream(zipFilename)) {
             fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
-            fileOutputStream.close();
         } catch (IOException e) {
             LOGGER.error("Could not download the current {} list with error ", listName, e);
         }
@@ -59,13 +57,13 @@ public abstract class ZipFileProvider implements ITargetListProvider {
             }
             File newFile = new File(outputFile);
             // write file content
-            FileOutputStream fos = new FileOutputStream(newFile);
-            int len;
-            byte[] buffer = new byte[1024];
-            while ((len = zis.read(buffer)) > 0) {
-                fos.write(buffer, 0, len);
+            try (FileOutputStream fos = new FileOutputStream(newFile)) {
+                int len;
+                byte[] buffer = new byte[1024];
+                while ((len = zis.read(buffer)) > 0) {
+                    fos.write(buffer, 0, len);
+                }
             }
-            fos.close();
         } catch (IOException e) {
             LOGGER.error("Could not unzip the current {} list with error ", listName, e);
         }


### PR DESCRIPTION
## Summary
- Fixed resource leaks in ZipFileProvider by using try-with-resources blocks
- Ensured proper closure of ReadableByteChannel and FileOutputStream instances
- Prevents potential file handle exhaustion issues

## Changes Made
1. Modified the download section to use try-with-resources for both ReadableByteChannel and FileOutputStream
2. Modified the unzipping section to use nested try-with-resources for FileOutputStream
3. All resources are now guaranteed to be closed even if exceptions occur

## Test Plan
- Code compiles successfully with `mvn clean compile`
- All formatting rules pass with `mvn spotless:apply`
- The functionality remains unchanged - only resource management is improved