### PR TITLE
Fix static method declarations

### DIFF
--- a/src/main/java/de/rub/nds/crawler/denylist/DenylistFileProvider.java
+++ b/src/main/java/de/rub/nds/crawler/denylist/DenylistFileProvider.java
@@ -58,7 +58,7 @@ public class DenylistFileProvider implements IDenylistProvider {
         }
     }
 
-    private boolean isInSubnet(String ip, SubnetUtils.SubnetInfo subnetInfo) {
+    private static boolean isInSubnet(String ip, SubnetUtils.SubnetInfo subnetInfo) {
         try {
             return subnetInfo.isInRange(ip);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/de/rub/nds/crawler/targetlist/ZipFileProvider.java
+++ b/src/main/java/de/rub/nds/crawler/targetlist/ZipFileProvider.java
@@ -91,7 +91,7 @@ public abstract class ZipFileProvider implements ITargetListProvider {
         return targetList;
     }
 
-    private InflaterInputStream getZipInputStream(String filename) throws IOException {
+    private static InflaterInputStream getZipInputStream(String filename) throws IOException {
         if (filename.contains(".gz")) {
             return new GZIPInputStream(new FileInputStream(filename));
         } else {


### PR DESCRIPTION
## Summary
- Fixed static method declarations as identified by static analysis
- Made `isInSubnet` method static in DenylistFileProvider.java
- Made `getZipInputStream` method static in ZipFileProvider.java

## Changes
Both methods don't use any instance variables and can be declared as static to improve code clarity and potentially performance.

## Test plan
- [x] Code compiles successfully
- [x] Spotless formatting applied
- [x] Existing tests pass (note: there was a pre-existing test failure in ScanTargetTest unrelated to these changes)