### PR TITLE
Fix CT_CONSTRUCTOR_THROW SpotBugs issues

### DIFF
--- a/src/main/java/de/rub/nds/crawler/data/ScanResult.java
+++ b/src/main/java/de/rub/nds/crawler/data/ScanResult.java
@@ -14,7 +14,7 @@ import java.io.Serializable;
 import java.util.UUID;
 import org.bson.Document;
 
-public class ScanResult implements Serializable {
+public final class ScanResult implements Serializable {
 
     private String id;
 

--- a/src/main/java/de/rub/nds/crawler/orchestration/RabbitMqOrchestrationProvider.java
+++ b/src/main/java/de/rub/nds/crawler/orchestration/RabbitMqOrchestrationProvider.java
@@ -35,7 +35,7 @@ import org.apache.logging.log4j.Logger;
  * Provides all methods required for the communication with RabbitMQ for the controller and the
  * worker.
  */
-public class RabbitMqOrchestrationProvider implements IOrchestrationProvider {
+public final class RabbitMqOrchestrationProvider implements IOrchestrationProvider {
 
     private static final Logger LOGGER = LogManager.getLogger();
 

--- a/src/main/java/de/rub/nds/crawler/persistence/MongoPersistenceProvider.java
+++ b/src/main/java/de/rub/nds/crawler/persistence/MongoPersistenceProvider.java
@@ -45,7 +45,7 @@ import org.bson.UuidRepresentation;
 import org.mongojack.JacksonMongoCollection;
 
 /** A persistence provider implementation using MongoDB as the persistence layer. */
-public class MongoPersistenceProvider implements IPersistenceProvider {
+public final class MongoPersistenceProvider implements IPersistenceProvider {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private static final String BULK_SCAN_COLLECTION_NAME = "bulkScans";


### PR DESCRIPTION
## Summary
- Made ScanResult, RabbitMqOrchestrationProvider, and MongoPersistenceProvider classes final
- This prevents finalizer attacks when these constructors throw exceptions
- Addresses SpotBugs issue #19: BAD_PRACTICE/CT_CONSTRUCTOR_THROW

## Test plan
- [x] Verified SpotBugs no longer reports CT_CONSTRUCTOR_THROW issues
- [x] Ran existing unit tests (one pre-existing test failure unrelated to changes)
- [x] Applied spotless formatting
- [x] Code compiles successfully