### PR TITLE
Move parallelProbes from worker config to ScanConfig

### DIFF
--- a/src/main/java/de/rub/nds/crawler/config/ControllerCommandConfig.java
+++ b/src/main/java/de/rub/nds/crawler/config/ControllerCommandConfig.java
@@ -64,6 +64,13 @@ public abstract class ControllerCommandConfig {
     private List<ProbeType> excludedProbes = new LinkedList<>();
 
     @Parameter(
+            names = "-parallelProbes",
+            validateWith = PositiveInteger.class,
+            description =
+                    "Number of probes to run in parallel per scan target. If set to 1, only one specific probe can be run in time per scan target. WARNING: For large scale scans, this should be kept at 1 to avoid excessive resource consumption and potential instability.")
+    private int parallelProbes = 1;
+
+    @Parameter(
             names = "-scanCronInterval",
             validateWith = CronSyntax.class,
             description =
@@ -179,6 +186,10 @@ public abstract class ControllerCommandConfig {
         return excludedProbes;
     }
 
+    public int getParallelProbes() {
+        return parallelProbes;
+    }
+
     public String getScanCronInterval() {
         return scanCronInterval;
     }
@@ -235,11 +246,13 @@ public abstract class ControllerCommandConfig {
     public abstract ScanConfig getScanConfig();
 
     public BulkScan createBulkScan() {
+        ScanConfig scanConfig = getScanConfig();
+        scanConfig.setParallelProbes(getParallelProbes());
         return new BulkScan(
                 getScannerClassForVersion(),
                 getCrawlerClassForVersion(),
                 getScanName(),
-                getScanConfig(),
+                scanConfig,
                 System.currentTimeMillis(),
                 isMonitored(),
                 getNotifyUrl());
@@ -265,6 +278,10 @@ public abstract class ControllerCommandConfig {
 
     public void setExcludedProbes(List<ProbeType> excludedProbes) {
         this.excludedProbes = excludedProbes;
+    }
+
+    public void setParallelProbes(int parallelProbes) {
+        this.parallelProbes = parallelProbes;
     }
 
     public void setScanCronInterval(String scanCronInterval) {

--- a/src/main/java/de/rub/nds/crawler/config/ControllerCommandConfig.java
+++ b/src/main/java/de/rub/nds/crawler/config/ControllerCommandConfig.java
@@ -247,7 +247,6 @@ public abstract class ControllerCommandConfig {
 
     public BulkScan createBulkScan() {
         ScanConfig scanConfig = getScanConfig();
-        scanConfig.setParallelProbes(getParallelProbes());
         return new BulkScan(
                 getScannerClassForVersion(),
                 getCrawlerClassForVersion(),

--- a/src/main/java/de/rub/nds/crawler/config/ControllerCommandConfig.java
+++ b/src/main/java/de/rub/nds/crawler/config/ControllerCommandConfig.java
@@ -246,12 +246,11 @@ public abstract class ControllerCommandConfig {
     public abstract ScanConfig getScanConfig();
 
     public BulkScan createBulkScan() {
-        ScanConfig scanConfig = getScanConfig();
         return new BulkScan(
                 getScannerClassForVersion(),
                 getCrawlerClassForVersion(),
                 getScanName(),
-                scanConfig,
+                getScanConfig(),
                 System.currentTimeMillis(),
                 isMonitored(),
                 getNotifyUrl());

--- a/src/main/java/de/rub/nds/crawler/config/WorkerCommandConfig.java
+++ b/src/main/java/de/rub/nds/crawler/config/WorkerCommandConfig.java
@@ -36,12 +36,6 @@ public class WorkerCommandConfig {
     private int parallelConnectionThreads = 20;
 
     @Parameter(
-            names = "-parallelProbes",
-            description =
-                    "Number of threads responsible for different probes. If set to 1, only one specific probe can be run in time per scan target. WARNING: For large scale scans, this should be kept at 1 to avoid excessive resource consumption and potential instability.")
-    private int parallelProbes = 1;
-
-    @Parameter(
             names = "-scanTimeout",
             description =
                     "Overall timeout for one scan in ms. (Default 14 minutes)"
@@ -74,14 +68,6 @@ public class WorkerCommandConfig {
         return scanTimeout;
     }
 
-    /**
-     * Returns the number of threads responsible for different probes. For large scale scans, this
-     * should be kept at 1 to avoid excessive resource consumption and potential instability.
-     */
-    public int getParallelProbes() {
-        return parallelProbes;
-    }
-
     public void setParallelScanThreads(int parallelScanThreads) {
         this.parallelScanThreads = parallelScanThreads;
     }
@@ -92,13 +78,5 @@ public class WorkerCommandConfig {
 
     public void setScanTimeout(int scanTimeout) {
         this.scanTimeout = scanTimeout;
-    }
-
-    /**
-     * Sets the number of threads responsible for different probes. WARNING: For large scale scans,
-     * this should be kept at 1 to avoid excessive resource consumption and potential instability.
-     */
-    public void setParallelProbes(int parallelProbes) {
-        this.parallelProbes = parallelProbes;
     }
 }

--- a/src/main/java/de/rub/nds/crawler/core/BulkScanWorkerManager.java
+++ b/src/main/java/de/rub/nds/crawler/core/BulkScanWorkerManager.java
@@ -154,9 +154,6 @@ public class BulkScanWorkerManager {
             int parallelConnectionThreads,
             int parallelScanThreads,
             IPersistenceProvider persistenceProvider) {
-        if (scanJobDescription.getBulkScanInfo().getScanConfig().getParallelProbes() <= 0) {
-            scanJobDescription.getBulkScanInfo().getScanConfig().setParallelProbes(1);
-        }
         BulkScanInfo bulkScanInfo = scanJobDescription.getBulkScanInfo();
         BulkScanWorker<?> worker =
                 getBulkScanWorker(

--- a/src/main/java/de/rub/nds/crawler/core/BulkScanWorkerManager.java
+++ b/src/main/java/de/rub/nds/crawler/core/BulkScanWorkerManager.java
@@ -73,39 +73,11 @@ public class BulkScanWorkerManager {
             int parallelConnectionThreads,
             int parallelScanThreads,
             IPersistenceProvider persistenceProvider) {
-        return handleStatic(
-                scanJobDescription,
-                parallelConnectionThreads,
-                parallelScanThreads,
-                1,
-                persistenceProvider);
-    }
-
-    /**
-     * Static convenience method to handle a scan job. See also {@link #handle(ScanJobDescription,
-     * int, int, int, IPersistenceProvider)}.
-     *
-     * @param scanJobDescription The scan job to handle
-     * @param parallelConnectionThreads The number of parallel connection threads to use (used to
-     *     create worker if it does not exist)
-     * @param parallelScanThreads The number of parallel scan threads to use (used to create worker
-     *     if it does not exist)
-     * @param parallelProbes The number of probes to run in parallel per scan target
-     * @param persistenceProvider The persistence provider for writing partial results
-     * @return A ProgressableFuture representing the scan lifecycle
-     */
-    public static ProgressableFuture<Document> handleStatic(
-            ScanJobDescription scanJobDescription,
-            int parallelConnectionThreads,
-            int parallelScanThreads,
-            int parallelProbes,
-            IPersistenceProvider persistenceProvider) {
         BulkScanWorkerManager manager = getInstance();
         return manager.handle(
                 scanJobDescription,
                 parallelConnectionThreads,
                 parallelScanThreads,
-                parallelProbes,
                 persistenceProvider);
     }
 
@@ -146,37 +118,6 @@ public class BulkScanWorkerManager {
             int parallelConnectionThreads,
             int parallelScanThreads,
             IPersistenceProvider persistenceProvider) {
-        return getBulkScanWorker(
-                bulkScanId,
-                scanConfig,
-                parallelConnectionThreads,
-                parallelScanThreads,
-                1,
-                persistenceProvider);
-    }
-
-    /**
-     * Gets or creates a bulk scan worker for the specified bulk scan. Workers are cached and reused
-     * to ensure thread limits.
-     *
-     * @param bulkScanId The ID of the bulk scan to get the worker for (used as key in the cache)
-     * @param scanConfig The scan configuration (used to create worker if it does not exist)
-     * @param parallelConnectionThreads The number of parallel connection threads to use (used to
-     *     create worker if it does not exist)
-     * @param parallelScanThreads The number of parallel scan threads to use (used to create worker
-     *     if it does not exist)
-     * @param parallelProbes The number of probes to run in parallel per scan target
-     * @param persistenceProvider The persistence provider for writing partial results
-     * @return A bulk scan worker for the specified bulk scan
-     * @throws UncheckedException If a worker cannot be created
-     */
-    public BulkScanWorker<?> getBulkScanWorker(
-            String bulkScanId,
-            ScanConfig scanConfig,
-            int parallelConnectionThreads,
-            int parallelScanThreads,
-            int parallelProbes,
-            IPersistenceProvider persistenceProvider) {
         try {
             return bulkScanWorkers.get(
                     bulkScanId,
@@ -186,7 +127,6 @@ public class BulkScanWorkerManager {
                                         bulkScanId,
                                         parallelConnectionThreads,
                                         parallelScanThreads,
-                                        parallelProbes,
                                         persistenceProvider);
                         ret.init();
                         return ret;
@@ -214,33 +154,9 @@ public class BulkScanWorkerManager {
             int parallelConnectionThreads,
             int parallelScanThreads,
             IPersistenceProvider persistenceProvider) {
-        return handle(
-                scanJobDescription,
-                parallelConnectionThreads,
-                parallelScanThreads,
-                1,
-                persistenceProvider);
-    }
-
-    /**
-     * Handles a scan job by creating or retrieving the appropriate worker and submitting the scan
-     * target for processing.
-     *
-     * @param scanJobDescription The scan job to handle
-     * @param parallelConnectionThreads The number of parallel connection threads to use (used to
-     *     create worker if it does not exist)
-     * @param parallelScanThreads The number of parallel scan threads to use (used to create worker
-     *     if it does not exist)
-     * @param parallelProbes The number of probes to run in parallel per scan target
-     * @param persistenceProvider The persistence provider for writing partial results
-     * @return A ProgressableFuture representing the scan lifecycle
-     */
-    public ProgressableFuture<Document> handle(
-            ScanJobDescription scanJobDescription,
-            int parallelConnectionThreads,
-            int parallelScanThreads,
-            int parallelProbes,
-            IPersistenceProvider persistenceProvider) {
+        if (scanJobDescription.getBulkScanInfo().getScanConfig().getParallelProbes() <= 0) {
+            scanJobDescription.getBulkScanInfo().getScanConfig().setParallelProbes(1);
+        }
         BulkScanInfo bulkScanInfo = scanJobDescription.getBulkScanInfo();
         BulkScanWorker<?> worker =
                 getBulkScanWorker(
@@ -248,7 +164,6 @@ public class BulkScanWorkerManager {
                         bulkScanInfo.getScanConfig(),
                         parallelConnectionThreads,
                         parallelScanThreads,
-                        parallelProbes,
                         persistenceProvider);
         return worker.handle(scanJobDescription);
     }

--- a/src/main/java/de/rub/nds/crawler/core/Worker.java
+++ b/src/main/java/de/rub/nds/crawler/core/Worker.java
@@ -32,7 +32,6 @@ public class Worker {
 
     private final int parallelScanThreads;
     private final int parallelConnectionThreads;
-    private final int parallelProbes;
     private final int scanTimeout;
 
     /** Runs a lambda which waits for the scanning result and persists it. */
@@ -53,7 +52,6 @@ public class Worker {
         this.persistenceProvider = persistenceProvider;
         this.parallelScanThreads = commandConfig.getParallelScanThreads();
         this.parallelConnectionThreads = commandConfig.getParallelConnectionThreads();
-        this.parallelProbes = commandConfig.getParallelProbes();
         this.scanTimeout = commandConfig.getScanTimeout();
 
         workerExecutor =
@@ -99,7 +97,6 @@ public class Worker {
                         scanJobDescription,
                         parallelConnectionThreads,
                         parallelScanThreads,
-                        parallelProbes,
                         persistenceProvider);
 
         workerExecutor.submit(

--- a/src/main/java/de/rub/nds/crawler/data/ScanConfig.java
+++ b/src/main/java/de/rub/nds/crawler/data/ScanConfig.java
@@ -27,7 +27,7 @@ public abstract class ScanConfig implements Serializable {
 
     private int timeout;
 
-    private int parallelProbes = 1;
+    private int parallelProbes;
 
     private List<ProbeType> excludedProbes;
 
@@ -40,24 +40,9 @@ public abstract class ScanConfig implements Serializable {
      * @param scannerDetail The level of detail for the scan
      * @param reexecutions The number of times to retry failed scans
      * @param timeout The timeout for each scan in seconds
+     * @param parallelProbes The number of probes to run in parallel per scan target
+     * @param excludedProbes The list of probes that should be excluded from the scan
      */
-    protected ScanConfig(ScannerDetail scannerDetail, int reexecutions, int timeout) {
-        this(scannerDetail, reexecutions, timeout, 1, null);
-    }
-
-    protected ScanConfig(
-            ScannerDetail scannerDetail,
-            int reexecutions,
-            int timeout,
-            List<ProbeType> excludedProbes) {
-        this(scannerDetail, reexecutions, timeout, 1, excludedProbes);
-    }
-
-    protected ScanConfig(
-            ScannerDetail scannerDetail, int reexecutions, int timeout, int parallelProbes) {
-        this(scannerDetail, reexecutions, timeout, parallelProbes, null);
-    }
-
     protected ScanConfig(
             ScannerDetail scannerDetail,
             int reexecutions,

--- a/src/main/java/de/rub/nds/crawler/data/ScanConfig.java
+++ b/src/main/java/de/rub/nds/crawler/data/ScanConfig.java
@@ -27,6 +27,8 @@ public abstract class ScanConfig implements Serializable {
 
     private int timeout;
 
+    private int parallelProbes = 1;
+
     private List<ProbeType> excludedProbes;
 
     @SuppressWarnings("unused")
@@ -40,7 +42,7 @@ public abstract class ScanConfig implements Serializable {
      * @param timeout The timeout for each scan in seconds
      */
     protected ScanConfig(ScannerDetail scannerDetail, int reexecutions, int timeout) {
-        this(scannerDetail, reexecutions, timeout, null);
+        this(scannerDetail, reexecutions, timeout, 1, null);
     }
 
     protected ScanConfig(
@@ -48,9 +50,24 @@ public abstract class ScanConfig implements Serializable {
             int reexecutions,
             int timeout,
             List<ProbeType> excludedProbes) {
+        this(scannerDetail, reexecutions, timeout, 1, excludedProbes);
+    }
+
+    protected ScanConfig(
+            ScannerDetail scannerDetail, int reexecutions, int timeout, int parallelProbes) {
+        this(scannerDetail, reexecutions, timeout, parallelProbes, null);
+    }
+
+    protected ScanConfig(
+            ScannerDetail scannerDetail,
+            int reexecutions,
+            int timeout,
+            int parallelProbes,
+            List<ProbeType> excludedProbes) {
         this.scannerDetail = scannerDetail;
         this.reexecutions = reexecutions;
         this.timeout = timeout;
+        this.parallelProbes = parallelProbes;
         this.excludedProbes = excludedProbes;
     }
 
@@ -86,6 +103,14 @@ public abstract class ScanConfig implements Serializable {
     }
 
     /**
+     * Returns the number of threads responsible for different probes. For large scale scans, this
+     * should be kept at 1 to avoid excessive resource consumption and potential instability.
+     */
+    public int getParallelProbes() {
+        return this.parallelProbes;
+    }
+
+    /**
      * Sets the scanner detail level.
      *
      * @param scannerDetail The scanner detail level
@@ -117,6 +142,14 @@ public abstract class ScanConfig implements Serializable {
     }
 
     /**
+     * Sets the number of threads responsible for different probes. WARNING: For large scale scans,
+     * this should be kept at 1 to avoid excessive resource consumption and potential instability.
+     */
+    public void setParallelProbes(int parallelProbes) {
+        this.parallelProbes = parallelProbes;
+    }
+
+    /**
      * Creates a worker for this scan configuration. Each implementation must provide a factory
      * method to create the appropriate worker type.
      *
@@ -131,27 +164,4 @@ public abstract class ScanConfig implements Serializable {
             int parallelConnectionThreads,
             int parallelScanThreads,
             IPersistenceProvider persistenceProvider);
-
-    /**
-     * Creates a worker for this scan configuration and configures probe-level parallelism.
-     * Implementations can override this method to support probe-level parallelism directly. Default
-     * behavior delegates to {@link #createWorker(String, int, int, IPersistenceProvider)} for
-     * backward compatibility.
-     *
-     * @param bulkScanID The ID of the bulk scan this worker is for
-     * @param parallelConnectionThreads The number of parallel connection threads to use
-     * @param parallelScanThreads The number of parallel scan threads to use
-     * @param parallelProbes The number of probes to run in parallel per scan target
-     * @param persistenceProvider The persistence provider for writing partial results
-     * @return A worker for this scan configuration
-     */
-    public BulkScanWorker<? extends ScanConfig> createWorker(
-            String bulkScanID,
-            int parallelConnectionThreads,
-            int parallelScanThreads,
-            int parallelProbes,
-            IPersistenceProvider persistenceProvider) {
-        return createWorker(
-                bulkScanID, parallelConnectionThreads, parallelScanThreads, persistenceProvider);
-    }
 }

--- a/src/test/java/de/rub/nds/crawler/config/ControllerCommandConfigTest.java
+++ b/src/test/java/de/rub/nds/crawler/config/ControllerCommandConfigTest.java
@@ -1,0 +1,37 @@
+/*
+ * TLS-Crawler - A TLS scanning tool to perform large scale scans with the TLS-Scanner
+ *
+ * Copyright 2018-2023 Ruhr University Bochum, Paderborn University, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.crawler.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.beust.jcommander.JCommander;
+import de.rub.nds.crawler.data.BulkScan;
+import de.rub.nds.crawler.dummy.DummyControllerCommandConfig;
+import org.junit.jupiter.api.Test;
+
+class ControllerCommandConfigTest {
+
+    @Test
+    void parallelProbesDefaultsToOneAndParses() {
+        ControllerCommandConfig config = new DummyControllerCommandConfig();
+        assertEquals(1, config.getParallelProbes());
+
+        JCommander.newBuilder().addObject(config).build().parse("-parallelProbes", "7");
+        assertEquals(7, config.getParallelProbes());
+    }
+
+    @Test
+    void createBulkScanPropagatesParallelProbesToScanConfig() {
+        DummyControllerCommandConfig config = new DummyControllerCommandConfig();
+        config.setParallelProbes(4);
+
+        BulkScan bulkScan = config.createBulkScan();
+        assertEquals(4, bulkScan.getScanConfig().getParallelProbes());
+    }
+}

--- a/src/test/java/de/rub/nds/crawler/config/WorkerCommandConfigTest.java
+++ b/src/test/java/de/rub/nds/crawler/config/WorkerCommandConfigTest.java
@@ -16,23 +16,15 @@ import org.junit.jupiter.api.Test;
 class WorkerCommandConfigTest {
 
     @Test
-    void parallelProbesDefaultsToOneAndParsesWithThreadOptions() {
+    void parsesWorkerThreadOptions() {
         WorkerCommandConfig config = new WorkerCommandConfig();
-        assertEquals(1, config.getParallelProbes());
 
         JCommander.newBuilder()
                 .addObject(config)
                 .build()
-                .parse(
-                        "-numberOfThreads",
-                        "4",
-                        "-parallelProbeThreads",
-                        "12",
-                        "-parallelProbes",
-                        "3");
+                .parse("-numberOfThreads", "4", "-parallelProbeThreads", "12");
 
         assertEquals(4, config.getParallelScanThreads());
         assertEquals(12, config.getParallelConnectionThreads());
-        assertEquals(3, config.getParallelProbes());
     }
 }

--- a/src/test/java/de/rub/nds/crawler/core/BulkScanWorkerManagerTest.java
+++ b/src/test/java/de/rub/nds/crawler/core/BulkScanWorkerManagerTest.java
@@ -39,23 +39,9 @@ class BulkScanWorkerManagerTest {
                 int parallelConnectionThreads,
                 int parallelScanThreads,
                 IPersistenceProvider persistenceProvider) {
+            capturedParallelProbes = getParallelProbes();
             return new CapturingBulkScanWorker(
                     bulkScanID, this, parallelScanThreads, persistenceProvider);
-        }
-
-        @Override
-        public BulkScanWorker<? extends ScanConfig> createWorker(
-                String bulkScanID,
-                int parallelConnectionThreads,
-                int parallelScanThreads,
-                int parallelProbes,
-                IPersistenceProvider persistenceProvider) {
-            capturedParallelProbes = parallelProbes;
-            return createWorker(
-                    bulkScanID,
-                    parallelConnectionThreads,
-                    parallelScanThreads,
-                    persistenceProvider);
         }
     }
 
@@ -85,21 +71,22 @@ class BulkScanWorkerManagerTest {
     @Test
     void getBulkScanWorkerPropagatesParallelProbes() {
         CapturingScanConfig scanConfig = new CapturingScanConfig();
+        scanConfig.setParallelProbes(9);
         BulkScanWorkerManager.getInstance()
                 .getBulkScanWorker(
                         "bulk-scan-" + System.nanoTime(),
                         scanConfig,
                         5,
                         2,
-                        9,
                         new DummyPersistenceProvider());
 
         assertEquals(9, scanConfig.getCapturedParallelProbes());
     }
 
     @Test
-    void oldGetBulkScanWorkerSignatureDefaultsParallelProbesToOne() {
+    void oldGetBulkScanWorkerSignatureUsesScanConfigParallelProbes() {
         CapturingScanConfig scanConfig = new CapturingScanConfig();
+        scanConfig.setParallelProbes(6);
         BulkScanWorkerManager.getInstance()
                 .getBulkScanWorker(
                         "bulk-scan-" + System.nanoTime(),
@@ -108,6 +95,6 @@ class BulkScanWorkerManagerTest {
                         2,
                         new DummyPersistenceProvider());
 
-        assertEquals(1, scanConfig.getCapturedParallelProbes());
+        assertEquals(6, scanConfig.getCapturedParallelProbes());
     }
 }

--- a/src/test/java/de/rub/nds/crawler/core/BulkScanWorkerManagerTest.java
+++ b/src/test/java/de/rub/nds/crawler/core/BulkScanWorkerManagerTest.java
@@ -16,6 +16,7 @@ import de.rub.nds.crawler.dummy.DummyPersistenceProvider;
 import de.rub.nds.crawler.persistence.IPersistenceProvider;
 import de.rub.nds.scanner.core.config.ScannerDetail;
 import java.io.Serializable;
+import java.util.List;
 import java.util.function.Consumer;
 import org.bson.Document;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,7 @@ class BulkScanWorkerManagerTest {
         private int capturedParallelProbes = -1;
 
         CapturingScanConfig() {
-            super(ScannerDetail.NORMAL, 0, 60);
+            super(ScannerDetail.NORMAL, 0, 60, 1, List.of());
         }
 
         int getCapturedParallelProbes() {

--- a/src/test/java/de/rub/nds/crawler/core/BulkScanWorkerTest.java
+++ b/src/test/java/de/rub/nds/crawler/core/BulkScanWorkerTest.java
@@ -30,7 +30,7 @@ class BulkScanWorkerTest {
     // Test implementation of ScanConfig
     static class TestScanConfig extends ScanConfig implements Serializable {
         public TestScanConfig() {
-            super(de.rub.nds.scanner.core.config.ScannerDetail.NORMAL, 0, 60);
+            super(de.rub.nds.scanner.core.config.ScannerDetail.NORMAL, 0, 60, 1, List.of());
         }
 
         @Override

--- a/src/test/java/de/rub/nds/crawler/core/ControllerTest.java
+++ b/src/test/java/de/rub/nds/crawler/core/ControllerTest.java
@@ -85,6 +85,7 @@ class ControllerTest {
             Assertions.assertEquals(2, jobExcludedProbes.size());
             Assertions.assertEquals("probe1", jobExcludedProbes.get(0).getName());
             Assertions.assertEquals("probe2", jobExcludedProbes.get(1).getName());
+            Assertions.assertEquals(1, job.getBulkScanInfo().getScanConfig().getParallelProbes());
         }
     }
 

--- a/src/test/java/de/rub/nds/crawler/dummy/DummyControllerCommandConfig.java
+++ b/src/test/java/de/rub/nds/crawler/dummy/DummyControllerCommandConfig.java
@@ -18,7 +18,8 @@ public class DummyControllerCommandConfig extends ControllerCommandConfig {
 
     @Override
     public ScanConfig getScanConfig() {
-        return new ScanConfig(ScannerDetail.NORMAL, 1, 1, getExcludedProbes()) {
+        return new ScanConfig(
+                ScannerDetail.NORMAL, 1, 1, getParallelProbes(), getExcludedProbes()) {
             @Override
             public BulkScanWorker<? extends ScanConfig> createWorker(
                     String bulkScanID,

--- a/src/test/java/de/rub/nds/crawler/dummy/DummyPersistenceProviderTest.java
+++ b/src/test/java/de/rub/nds/crawler/dummy/DummyPersistenceProviderTest.java
@@ -19,6 +19,7 @@ import de.rub.nds.crawler.data.ScanResult;
 import de.rub.nds.crawler.data.ScanTarget;
 import de.rub.nds.crawler.persistence.IPersistenceProvider;
 import de.rub.nds.scanner.core.config.ScannerDetail;
+import java.util.List;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ class DummyPersistenceProviderTest {
 
         // Create a test BulkScan
         ScanConfig scanConfig =
-                new ScanConfig(ScannerDetail.NORMAL, 1, 5000) {
+                new ScanConfig(ScannerDetail.NORMAL, 1, 5000, 1, List.of()) {
                     @Override
                     public BulkScanWorker<? extends ScanConfig> createWorker(
                             String bulkScanID,


### PR DESCRIPTION
This PR moves `parallelProbes`, introduced in https://github.com/tls-attacker/Crawler-Core/pull/69, from worker configuration to scan configuration:
- Added `parallelProbes` to controller-side scan creation (`ControllerCommandConfig` -> `ScanConfig`).
- Removed worker-side `-parallelProbes` from `WorkerCommandConfig`.
- Workers now read/apply `parallelProbes` from job scan config, with fallback to `1` for invalid values.